### PR TITLE
[config] MYSQL configurations to env

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
- DATABASE_URL="mysql://user:pw@mysql:3306/miserend?serverVersion=8.0.32&charset=utf8mb4"
+ DATABASE_URL="mysql://${MISEREND_MYSQL_USER}:${MISEREND_MYSQL_PASSWORD}@mysql:3306/${MISEREND_MYSQL_DATABASE}?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -9,10 +9,10 @@
 
 $environment['default'] = [
     'connection' => [
-        'host' => env('MYSQL_MISEREND_HOST', 'mysql'),
-        'user' => env('MYSQL_MISEREND_USER', 'root'),
-        'password' => env('MYSQL_MISEREND_PASSWORD', '********'),
-        'database' => env('MYSQL_MISEREND_DATABASE', 'miserend'),
+        'host' => 'mysql'),
+        'user' => getenv('MISEREND_MYSQL_USER'),
+        'password' => getenv('MISEREND_MYSQL_PASSWORD'),
+        'database' => getenv('MISEREND_MYSQL_DATABASE'),
     ],
     'path' => [
         'domain' => 'https://miserend.hu',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,10 @@ services:
       - ./docker/mysql:/docker-entrypoint-initdb.d    
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: pw
-      MYSQL_DATABASE: miserend
-      MYSQL_USER: user
-      MYSQL_PASSWORD: pw
+      MYSQL_ROOT_PASSWORD: ${MISEREND_MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE:  ${MISEREND_MYSQL_DATABASE}
+      MYSQL_USER:  ${MISEREND_MYSQL_USER}
+      MYSQL_PASSWORD:  ${MISEREND_MYSQL_PASSWORD}
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost","-u","user","-ppw"]
       timeout: 5s


### PR DESCRIPTION
#230 kapcsán: ez így jobbnak tűnik? Így a MYSQL_USER és egyéb beállításokat az .env.local -ba kell megejteni egyetlen helyen és nincs beégetve. És ha nem csinálom meg a rendes .env.local fájlomat, akkor nem is indul el semmi és a .env az maradhat boldog no-touch zone.

issue: docker-compose.yml -ben a mysql healthcheck része nem működik még mert oda be van égetve a mysql név és jelszó!