### PR TITLE
Régi adatok figyelmeztetés ne jelenjen meg, ha nincs miserend.

### DIFF
--- a/webapp/templates/church/_schedule.twig
+++ b/webapp/templates/church/_schedule.twig
@@ -3,7 +3,7 @@
 {% set seven_years_ago = current_date|date_modify('-7 years')|date('Y-m-d') %}
 
  <div class="accordion accordion-flush position-relative" id="periods">
-  {% if updated_date < seven_years_ago %}
+  {% if updated_date < seven_years_ago and miserend.periods|length > 0 %}
     <div class="overlay" style="
             position: absolute;
             top: 0; left: 0; width: 100%; height: 100%;


### PR DESCRIPTION
A "Több mint hét éves adatok" overlay akkor is megjelenik, amikor nincs miserend és emiatt "szétesik" az oldal, a szöveg fölött lebeg az overlay, lásd: 
https://miserend.hu/templom/3506
Ebben a kicsi javításban nem engedem, hogy megjelenjen az overlay, ha nincs miserend.