### PR TITLE
Add Playwright E2E test suite (Docker + GitHub Actions) with login helpers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,56 @@
+name: Playwright E2E Tests
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start application services
+        run: |
+          docker compose -f docker/compose.yml -f docker/compose.dev.yml up -d
+          
+      - name: Wait for application to be ready
+        run: |
+          timeout 120 bash -c 'until curl -f http://localhost:8000 > /dev/null 2>&1; do sleep 2; done'
+
+      - name: Run Playwright E2E tests
+        env:
+          E2E_ADMIN_USER: ${{ secrets.E2E_ADMIN_USER || 'admin' }}
+          E2E_ADMIN_PASS: ${{ secrets.E2E_ADMIN_PASS || 'miserend' }}
+          CI: true
+        run: |
+          docker compose -f docker/compose.yml -f docker/compose.dev.yml -f docker/compose.e2e.yml run --rm playwright
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: e2e/test-results/
+          retention-days: 7
+
+      - name: Stop services
+        if: always()
+        run: |
+          docker compose -f docker/compose.yml -f docker/compose.dev.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,13 @@ composer.phar
 # PHPUnit cache and coverage artifacts
 /webapp/tests/.phpunit*
 /webapp/tests/coverage/
+/webapp/tests/junit.xml
 
+# E2E tests
+/e2e/node_modules/
+/e2e/test-results/
+/e2e/playwright-report/
+/e2e/blob-report/
+/e2e/playwright/.cache/
+/e2e/.env
+/e2e/package-lock.json

--- a/docker/compose.e2e.yml
+++ b/docker/compose.e2e.yml
@@ -1,0 +1,18 @@
+services:
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.59.1-jammy
+    working_dir: /work/e2e
+    volumes:
+      - ../e2e:/work/e2e
+      - ../webapp:/work/webapp
+    environment:
+      E2E_ADMIN_USER: ${E2E_ADMIN_USER:-admin}
+      E2E_ADMIN_PASS: ${E2E_ADMIN_PASS:-miserend}
+      CI: ${CI:-false}
+      PLAYWRIGHT_IN_DOCKER: "true"
+    networks:
+      - inner
+    depends_on:
+      miserend:
+        condition: service_started
+    command: sh -c "npm install && npx playwright test"

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,5 @@
+# Playwright E2E credentials
+# Copy this file to .env and adjust as needed.
+
+E2E_ADMIN_USER=admin
+E2E_ADMIN_PASS=miserend

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,65 @@
+# Miserend.hu E2E Tests (Playwright)
+
+End-to-end tesztek Playwright használatával.
+
+## Futtatás Docker-ben (ajánlott)
+
+### Lokálisan
+```bash
+# Indítsd el az alkalmazást
+docker compose -f docker/compose.yml -f docker/compose.dev.yml up -d
+
+# Futtasd a teszteket
+docker compose -f docker/compose.yml -f docker/compose.dev.yml -f docker/compose.e2e.yml run --rm playwright
+
+# Leállítás
+docker compose -f docker/compose.yml -f docker/compose.dev.yml down
+```
+
+### Környezeti változók (opcionális)
+Hozz létre egy `e2e/.env` fájlt (lásd `.env.example`):
+```env
+E2E_ADMIN_USER=admin
+E2E_ADMIN_PASS=miserend
+```
+
+Vagy add meg futtatáskor:
+```bash
+E2E_ADMIN_USER=admin E2E_ADMIN_PASS=miserend docker compose -f docker/compose.yml -f docker/compose.dev.yml -f docker/compose.e2e.yml run --rm playwright
+```
+
+## Futtatás lokálisan (npm)
+
+Ha Docker nélkül szeretnéd futtatni (fejlesztéshez):
+
+### Telepítés
+```bash
+cd e2e
+npm install
+npx playwright install chromium
+```
+
+### Tesztek futtatása
+```bash
+npm test                  # headless
+npm run test:headed       # böngésző látható
+npm run test:ui           # interaktív UI
+npm run test:debug        # debug mód
+npm run report            # HTML riport
+```
+
+## GitHub Actions (CI)
+
+A tesztek automatikusan futnak GitHub Actions-ben minden push/PR esetén.
+A workflow: `.github/workflows/playwright.yml`
+
+Secrets beállítása (opcionális):
+- `E2E_ADMIN_USER`
+- `E2E_ADMIN_PASS`
+
+## Megjegyzések
+
+- **Docker módban**: a tesztek a `miserend` konténerhez csatlakoznak az `inner` hálózaton
+- **Lokál npm módban**: a tesztek automatikusan elindítják a Docker compose környezetet
+- CI környezetben 2 retry van beállítva
+- Screenshot és trace csak hiba esetén készül

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "miserend-e2e-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "test:debug": "playwright test --debug",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^22.10.2",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { defineConfig, devices } from '@playwright/test';
+
+const isDocker = process.env.PLAYWRIGHT_IN_DOCKER === 'true';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: isDocker ? 'http://miserend:8000' : 'http://localhost:8000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: isDocker ? undefined : {
+    command: 'docker compose -f docker/compose.yml -f docker/compose.dev.yml up',
+    url: 'http://localhost:8000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/e2e/tests/api-health.spec.ts
+++ b/e2e/tests/api-health.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('API Health Check', () => {
+  test('should respond to API health endpoint', async ({ request }) => {
+    const response = await request.get('/api/health');
+    
+    expect(response.status()).toBe(200);
+    
+    const body = await response.text();
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  test('should handle API version endpoint', async ({ request }) => {
+    const response = await request.get('/api/');
+    
+    expect(response.status()).toBeLessThan(500);
+  });
+});

--- a/e2e/tests/church-search.spec.ts
+++ b/e2e/tests/church-search.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Church Search', () => {
+  test('should search for a specific church from homepage and find it in results', async ({ page }) => {
+    await page.goto('/');
+    
+    const searchInput = page.locator('#keyword');
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill('Alkantarai Szent Péter');
+
+    const submitButton = page.locator('button[type="submit"][name="q"][value="SearchResultsChurches"]');
+    await expect(submitButton).toBeVisible();
+
+    await Promise.all([
+      page.waitForLoadState('networkidle'),
+      submitButton.click(),
+    ]);
+
+    await expect(page).toHaveURL(/\bq=SearchResultsChurches\b/);
+    await expect(page.locator('.church-site-main-content')).toContainText('Alkantarai Szent Péter');
+  });
+
+  test('should navigate to church detail page from search results', async ({ page }) => {
+    await page.goto('/?q=SearchResultsChurches&kulcsszo=Alkantarai');
+    
+    const churchLink = page.locator('.church-site-main-content a:has-text("Alkantarai Szent Péter")').first();
+    await expect(churchLink).toBeVisible();
+    
+    await churchLink.click();
+    
+    await page.waitForURL(/templom\/\d+/);
+    
+    const pageHeader = page.locator('.page-header h2, h2');
+    await expect(pageHeader).toContainText('Alkantarai');
+  });
+});

--- a/e2e/tests/helpers/auth.ts
+++ b/e2e/tests/helpers/auth.ts
@@ -1,0 +1,23 @@
+import type { Page } from '@playwright/test';
+
+export type LoginOptions = {
+  username: string;
+  password: string;
+};
+
+export async function login(page: Page, { username, password }: LoginOptions): Promise<void> {
+  await page.goto('/');
+
+  await page.locator('input[name="login"]').fill(username);
+  await page.locator('input[name="passw"]').fill(password);
+
+  await page.locator('input[name="login"]').press('Enter');
+  await page.waitForLoadState('networkidle');
+}
+
+export async function loginAsAdmin(page: Page): Promise<void> {
+  const username = process.env.E2E_ADMIN_USER ?? 'admin';
+  const password = process.env.E2E_ADMIN_PASS ?? 'miserend';
+
+  await login(page, { username, password });
+}

--- a/e2e/tests/homepage.spec.ts
+++ b/e2e/tests/homepage.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test('should load the homepage successfully', async ({ page }) => {
+    await page.goto('/');
+    
+    await expect(page).toHaveTitle(/miserend/i);
+    
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('should display church search input', async ({ page }) => {
+    await page.goto('/');
+    
+    const searchInput = page.locator('#keyword');
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toHaveAttribute('name', 'kulcsszo');
+  });
+
+  test('should navigate without errors', async ({ page }) => {
+    const response = await page.goto('/');
+    
+    expect(response?.status()).toBeLessThan(400);
+  });
+});

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { login, loginAsAdmin } from './helpers/auth';
+
+test.describe('User Login', () => {
+  test('should display login form on homepage', async ({ page }) => {
+    await page.goto('/');
+    
+    const loginInput = page.locator('input[name="login"]');
+    const passwordInput = page.locator('input[name="passw"]');
+    
+    await expect(loginInput).toBeVisible();
+    await expect(passwordInput).toBeVisible();
+    await expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+
+  test('should show error message for invalid credentials', async ({ page }) => {
+    await login(page, {
+      username: 'nonexistent_user_12345',
+      password: 'wrongpassword',
+    });
+
+    await page.waitForTimeout(1000);
+
+    const errorAlert = page.locator('#messages .alert-danger');
+    const errorCount = await errorAlert.count();
+
+    if (errorCount > 0) {
+      await expect(errorAlert.first()).toBeVisible();
+    } else {
+      const url = page.url();
+      expect(url).toContain('localhost:8000');
+      const usernameVisible = await page.locator('text=/nonexistent_user_12345/i').count();
+      expect(usernameVisible).toBe(0);
+    }
+  });
+
+  test('should not allow login with empty credentials', async ({ page }) => {
+    await login(page, {
+      username: '',
+      password: '',
+    });
+
+    const errorAlert = page.locator('#messages .alert-danger, .alert-danger');
+    const hasError = await errorAlert.count() > 0;
+
+    if (hasError) {
+      await expect(errorAlert).toBeVisible();
+    } else {
+      const currentUrl = page.url();
+      expect(currentUrl).toMatch(/localhost:8000/);
+    }
+  });
+
+  test('should have logout hidden input set to false by default', async ({ page }) => {
+    await page.goto('/');
+    
+    const logoutInput = page.locator('input[name="logout"]');
+    await expect(logoutInput).toHaveAttribute('type', 'hidden');
+    await expect(logoutInput).toHaveAttribute('value', 'false');
+  });
+
+  test('should successfully login with valid credentials', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const logoutButton = page.locator('div.menusav .navbar a', { hasText: /^Kilépés$/ });
+    await expect(logoutButton).toBeVisible({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
Ebben a PR-ben előkészítettem és integráltam a Playwright alapú E2E teszteket a projekthez.

- Playwright E2E tesztcsomag az e2e/ mappában, több stabil teszttel (homepage, templom keresés, login, API health)
- Közös auth helper (e2e/tests/helpers/auth.ts) a bejelentkezési flow újrafelhasználására
- .env támogatás E2E credential-ökhöz (.env betöltés a playwright.config.ts-ben + .env.example)
- Docker-es futtatás külön compose fájllal: docker/compose.e2e.yml
- GitHub Actions workflow hozzáadva: .github/workflows/playwright.yml
  - futtatás push/PR esetén
  - Playwright report + test-results artifact feltöltés
 
Eredmény: a tesztek lokálisan (npm és Docker módban) is futtathatók, és CI-ben is automatikusan lefutnak.