### PR TITLE
#375: engedékeny CORS a templom-képekre (canvas-export)

### DIFF
--- a/docker/miserend/Dockerfile
+++ b/docker/miserend/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install mysqli pdo pdo_mysql zip \
-    && a2enmod rewrite \
+    && a2enmod rewrite headers \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy repo root

--- a/docker/miserend/apache/apache.conf
+++ b/docker/miserend/apache/apache.conf
@@ -7,4 +7,13 @@
             AllowOverride All
             Require all granted
         </Directory>
+
+        # #375: a templom-képekre engedékeny CORS, hogy külső oldal (pl. a
+        # templom-terkep) canvasra rajzolhassa és plakátként exportálhassa őket
+        # (a "tainted canvas" hiba elkerülése). Csak a publikus kép-könyvtárra.
+        <Directory "/miserend/webapp/kepek">
+            <IfModule mod_headers.c>
+                Header set Access-Control-Allow-Origin "*"
+            </IfModule>
+        </Directory>
     </VirtualHost>


### PR DESCRIPTION
Kapcsolódik: #375.

**Probléma:** a templom-képek statikus fájlok (`/kepek/templomok/{id}/{file}`, az Apache szolgálja ki). A `templom-terkep` külső originről canvasra rajzolná és plakátként exportálná őket, de CORS-header hiányában „tainted canvas" hibát kap.

**Megoldás (borazslo 2. javaslata):** engedékeny CORS a képekre:
- `Dockerfile`: `a2enmod rewrite headers` (a `mod_headers` eddig nem volt bekapcsolva).
- `apache.conf`: a `/miserend/webapp/kepek` könyvtárra `Header set Access-Control-Allow-Origin "*"`. Csak a publikus kép-könyvtárra.

**Fontos a másik oldalon:** a `templom-terkep`-nek a képeket `crossOrigin="anonymous"`-szal kell betöltenie, különben a böngésző akkor sem használja canvason, ha a szerver küldi a headert. (Az a másik repó — jelzem ott is, ha kell.)

Image-rebuild kell hozzá (a header az új image Apache-configjából jön). Lokálisan `apache2ctl configtest`-et nem futtattam; a direktíva standard, a CI/staging a bizonyíték.