### PR TITLE
docs: domainek/környezetek táblázat a README-ben

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ A projekt háromféle tesztet használ: **ng-test** (Angular), **PHPUnit** (PHP 
 | `dev.miserend.hu` | Karbantartási tartalék-oldal (best-effort, a `webapp/0index.html` ide irányít leállás alatt; működése nem garantált) | — (nincs saját config-bejegyzés) |
 | `http://localhost:8000` | Helyi fejlesztés (Docker, `docker/compose.dev.yml`) | `development` |
 
-A környezetet a `MISEREND_WEBAPP_ENVIRONMENT` env-változó választja ki (alapértelmezés: `staging`). A `development` env nem ír felül `domain`-t, így a `default` (`https://miserend.hu`) öröklődik — helyi dev-en a `http://localhost:8000` már *secure context*, l. [CONTRIBUTING.md](CONTRIBUTING.md).
+A környezetet a `MISEREND_WEBAPP_ENVIRONMENT` env-változó választja ki (alapértelmezés: `staging`). A `development` env a `domain`-t `http://localhost:8000`-re állítja (hogy a mailcatcher-levelekben is jó legyen a domain teszteléskor); helyi dev-en ez már *secure context*, l. [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Éles / staging / UAT build
 Fejlesztés végén azonban egy megfelelő környezetbe való build kell, például:

--- a/README.md
+++ b/README.md
@@ -220,6 +220,17 @@ A projekt háromféle tesztet használ: **ng-test** (Angular), **PHPUnit** (PHP 
 - `master` ➜ staging környezet (`staging.miserend.hu`)
 - `production` ➜ éles honlap
 
+## 🌐 Domainek / környezetek
+
+| Domain | Szerep | Környezet (`webapp/config.php`) |
+|--------|--------|----------------------------------|
+| `miserend.hu` (+ `www.miserend.hu`) | Éles honlap (production) | `default` / `production` — `https://miserend.hu` |
+| `staging.miserend.hu` | Staging / deploy-target (a `master` ág ide megy) | `staging` — `http://staging.miserend.hu` |
+| `dev.miserend.hu` | Karbantartási tartalék-oldal (best-effort, a `webapp/0index.html` ide irányít leállás alatt; működése nem garantált) | — (nincs saját config-bejegyzés) |
+| `http://localhost:8000` | Helyi fejlesztés (Docker, `docker/compose.dev.yml`) | `development` |
+
+A környezetet a `MISEREND_WEBAPP_ENVIRONMENT` env-változó választja ki (alapértelmezés: `staging`). A `development` env nem ír felül `domain`-t, így a `default` (`https://miserend.hu`) öröklődik — helyi dev-en a `http://localhost:8000` már *secure context*, l. [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Éles / staging / UAT build
 Fejlesztés végén azonban egy megfelelő környezetbe való build kell, például:
 ```


### PR DESCRIPTION
A #523 kapcsán kiderült, hogy a nem-prod végpontok szerepe nincs sehol rögzítve (és kettő tört is). Ez a PR a **fő README-be** beteszi a domain→szerep táblát:

- `miserend.hu` (+ `www`) — éles (prod)
- `staging.miserend.hu` — staging / deploy-target (`master`)
- `dev.miserend.hu` — karbantartási tartalék (best-effort, a `0index.html` ide irányít)
- `http://localhost:8000` — helyi dev (Docker)

Plusz egy mondat a `MISEREND_WEBAPP_ENVIRONMENT`-ről és a `development` env domain-örökléséről. Csak dokumentáció.