### PR TITLE
Dev docker környezet javítása: miserend image helyi buildje

### DIFF
--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -19,6 +19,9 @@ services:
         aliases:
           - mailcatcher
   miserend:
+    build:
+      context: ..
+      dockerfile: docker/miserend/Dockerfile
     depends_on:
       npm-init:
         condition: service_completed_successfully

--- a/docker/miserend/Dockerfile
+++ b/docker/miserend/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /legacy
 COPY webapp/package*.json ./
 RUN npm ci
 
-FROM node:18 AS calendar-build
+FROM node:22 AS calendar-build
 
 WORKDIR /calendar
 

--- a/docker/miserend/Dockerfile.github
+++ b/docker/miserend/Dockerfile.github
@@ -5,7 +5,7 @@ WORKDIR /legacy
 COPY webapp/package*.json ./
 RUN npm ci
 
-FROM node:18 AS calendar-build
+FROM node:22 AS calendar-build
 
 WORKDIR /calendar
 

--- a/docker/miserend/Dockerfile.test
+++ b/docker/miserend/Dockerfile.test
@@ -5,7 +5,7 @@ WORKDIR /legacy
 COPY webapp/package*.json ./
 RUN npm ci
 
-FROM node:18 AS calendar-build
+FROM node:22 AS calendar-build
 
 WORKDIR /calendar
 


### PR DESCRIPTION
A compose.dev.yml eddig nem tudta felépíteni a miserend image-et, ezért a `docker compose up` a localhost registry-ből próbálta pullolni a localhost/miserend:latest image-et, ami időtúllépéssel elszállt. A miserend service-hez most build szekció kerül (context: repo gyökér, Dockerfile: docker/miserend/Dockerfile), így a README-ben leírt parancs elsőre felépíti és taggeli az image-et.

Emellett a calendar-build stage node:18-ról node:22-re vált, mert az Angular 21 legalább Node 20.19/22.12-t igényel (Dockerfile, Dockerfile.test, Dockerfile.github).