### PR TITLE
#375: CORS-header a képekre (canvas-export CORS-hiba)

### DIFF
--- a/webapp/.htaccess
+++ b/webapp/.htaccess
@@ -1,3 +1,14 @@
+# #375: a képek (kepek/) statikusan, közvetlenül szolgálódnak (lásd lentebb a
+# `^(vendor|kepek|...)/ - [L]` szabályt), így NEM mennek át az index.php-n, ahol a
+# CORS-header lenne. A canvas-export (templom-terkep) emiatt CORS-hibát dob. Minden
+# képre engedjük a cross-origin olvasást. IfModule-ba csomagolva: ha a mod_headers
+# nincs engedélyezve, csendben no-op (nem 500). Prod-on `a2enmod headers` kell hozzá.
+<IfModule mod_headers.c>
+    <FilesMatch "\.(jpe?g|png|gif|webp|svg|ico)$">
+        Header set Access-Control-Allow-Origin "*"
+    </FilesMatch>
+</IfModule>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews


### PR DESCRIPTION
Closes #375

A képeket (`kepek/`) az Apache **közvetlenül** szolgálja (a `.htaccess` `^(vendor|kepek|...)/ - [L]` szabálya miatt), így **nem mennek át az `index.php`-n**, ahol a CORS-header lenne. Ezért a canvas-export (templom-terkep) CORS-hibát dob a képek rajzolásakor.

**Fix:** `mod_headers` blokk minden képre (`jpg/png/gif/webp/svg/ico`) → `Access-Control-Allow-Origin: *`. `<IfModule mod_headers.c>`-be csomagolva: ha a `mod_headers` nincs engedélyezve, csendben no-op (nem 500).

**Validálva** (futó docker, `mod_headers` engedélyezve): a kép válasza tartalmazza az `Access-Control-Allow-Origin: *` headert (HTTP 200). A site-t nem töri (IfModule-guard).

**Deploy / teendő:**
- Prod Apache-on `a2enmod headers` kell hozzá (jelenleg nincs engedélyezve).
- A fogyasztó oldalon (`templom-terkep`) az `img.crossOrigin = "anonymous"` is kell a canvas-rajzolás előtt, különben a canvas a header ellenére is „tainted" marad. (Ez a másik repóban, jelzés a lezáráshoz.)
