### PR TITLE
#610: az SMTP-t env-ből konfigurálom, a hibák ne tűnjenek el némán

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,12 @@
 MISEREND_PORT=8000
 MISEREND_WEBAPP_ENVIRONMENT=development
+
+# SMTP (#610). Dev/test alatt üresen hagyható: ott a mailcatcher az alapértelmezés.
+# Production-ben KÖTELEZŐ, különben nem megy ki egyetlen levél sem (a /health pirosan jelzi).
+# A production compose ezeket a `docker/.env` fájlból olvassa (a compose.yml mellől).
+SMTP_HOST=
+SMTP_PORT=25
+SMTP_USER=
+SMTP_PASSWORD=
+# üres | tls | ssl
+SMTP_SECURE=

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Fejlesztői környezetben indul egy Mailcatcher is, ami a levelezés szimulálá
 
 Alapértelmezetten a http://localhost:11080/ oldalon lehet nyomon követni a kiküldött emaileket. 
 
+Éles (`production`) és `staging` környezetben viszont a mailcatcher **nem** alapértelmezés: ott az `SMTP_HOST` /
+`SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` / `SMTP_SECURE` env-változókat kötelező megadni (`docker/.env`, l.
+[docs/outgoing-connections.md](docs/outgoing-connections.md)). Ha nincs beállítva SMTP kiszolgáló, a rendszer nem
+küld ki levelet, és a `/health` oldal „Levelezőrendszer egészsége” blokkja pirosan jelzi az okát. (#610)
+
 
 ## Miserend web alkalmazás (PHP)
 

--- a/docker/compose.test.yml
+++ b/docker/compose.test.yml
@@ -16,5 +16,6 @@ services:
       dockerfile: docker/miserend/Dockerfile.test
     environment:
       - SMTP_HOST=mailcatcher
-      - SMTP_PORT=11025
+      # A 11025 a hoston publikált port; a compose-hálózaton belül a mailcatcher 1025-ön hallgat.
+      - SMTP_PORT=1025
       - MISEREND_WEBAPP_ENVIRONMENT=testing

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -81,8 +81,17 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
-    environment: 
+    # #610: az SMTP-beállításokat át KELL adni a konténernek. A `.env` önmagában csak a
+    # compose-fájl interpolációjához kell, a PHP-hez nem jut el belőle semmi. Enélkül a
+    # config.php alapértéke érvényesült, ami a dev mailcatcher-be küldött minden levelet.
+    # A `.env` a compose.yml mellé (docker/.env) kerül.
+    environment:
       - MISEREND_WEBAPP_ENVIRONMENT=production
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-25}
+      - SMTP_USER=${SMTP_USER:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_SECURE=${SMTP_SECURE:-}
 
     networks:
       inner:

--- a/docs/outgoing-connections.md
+++ b/docs/outgoing-connections.md
@@ -28,7 +28,22 @@
 
 ## SMTP (production)
 
-Production-ben a SMTP a `.env` `SMTP_HOST` / `SMTP_PORT` szerint (config.php `production` ág). Engedélyezni kell:
+Production-ben a levélküldés az alábbi env-változókból konfigurálódik (`webapp/config.php`, `smtp` ág):
+
+| Változó | Alapérték | Megjegyzés |
+|---|---|---|
+| `SMTP_HOST` | *(üres)* | **Kötelező.** Üresen a rendszer egyetlen levelet sem küld ki, a `/health` pirosan jelzi. |
+| `SMTP_PORT` | `25` | |
+| `SMTP_USER` | *(üres)* | Ha meg van adva, bekapcsolja az SMTP-autentikációt. |
+| `SMTP_PASSWORD` | *(üres)* | |
+| `SMTP_SECURE` | *(üres)* | `tls` vagy `ssl` |
+
+A `.env` a compose-fájl mellé kerül (`docker/.env`), és a `docker/compose.yml` `environment` blokkja adja tovább a
+konténernek. **A `.env` önmagában nem elég**: a compose csak a saját interpolációjához olvassa, a PHP-hez nem jut el
+belőle semmi, ha a service nem sorolja fel a változókat (ez volt a #610 gyökere — az SMTP így a dev `mailcatcher`
+alapértéken maradt és minden levél elveszett).
+
+Engedélyezni kell:
 
 | Cél | Host | Port |
 |---|---|---|

--- a/webapp/classes/api/table.php
+++ b/webapp/classes/api/table.php
@@ -135,6 +135,19 @@ class Table extends Api {
   
     function mapTemplomok() {
         $output = array();
+
+        // #542: a denomination az OSM-ből (attributes tábla 'denomination' kulcs,
+        // fromOSM=1) jön, nem a törékeny egyházmegye-id (17,18,34) heurisztikából.
+        // Egyszeri batch-load, hogy ne legyen N+1 az export során.
+        $churchIds = [];
+        foreach ($this->table as $r) {
+            if (isset($r->id)) { $churchIds[] = $r->id; }
+        }
+        $osmDenominations = empty($churchIds) ? [] :
+            \Eloquent\Attribute::whereIn('church_id', $churchIds)
+                ->where('key', 'denomination')
+                ->pluck('value', 'church_id')->toArray();
+
         foreach ($this->table as $row) {
             $tmp = array();
             foreach ($this->columns as $column) {
@@ -152,7 +165,12 @@ class Table extends Api {
                 switch ($column) {
                     case 'denomination':
                         //http://wiki.openstreetmap.org/wiki/Key:denomination#Christian_denominations
-                        if (in_array($row->egyhazmegye, array(17, 18, 34))) {
+                        // #542: elsődlegesen az OSM-denomination (attributes); ÁTMENETI
+                        // fallback az egyházmegye-heurisztika, amíg az OSM-sync nem fed le mindent.
+                        $cid = $row->id ?? null;
+                        if ($cid !== null && !empty($osmDenominations[$cid])) {
+                            $tmp[$column] = $osmDenominations[$cid];
+                        } elseif (in_array($row->egyhazmegye, array(17, 18, 34))) {
                             $tmp[$column] = 'greek_catholic';
                         } else {
                             $tmp[$column] = 'roman_catholic';

--- a/webapp/classes/eloquent/church.php
+++ b/webapp/classes/eloquent/church.php
@@ -1033,7 +1033,18 @@ class Church extends \Illuminate\Database\Eloquent\Model {
     }
 
     public function getDenominationAttribute($value) {
-        return  in_array($this->egyhazmegye,[34,17,18]) ? 'greek_catholic' : 'roman_catholic';
+        // #542 (borazslo): a denomination az OSM-ből származzon — az `attributes` tábla
+        // 'denomination' kulcsából (fromOSM=1, az OSM-sync tölti) —, nem a törékeny
+        // egyházmegye-id (17,18,34) heurisztikából. A `templomok.denomination` oszlop
+        // kivezetésre szánt (mindig NULL, semmi nem írja).
+        // ÁTMENETI fallback: amíg az OSM-sync nem fed le minden templomot, a korábbi
+        // egyházmegye-alapú érték marad (regresszió-mentesség) — eltávolítható, ha az
+        // OSM-denomination minden templomra megvan.
+        $osm = $this->attributes()->where('key', 'denomination')->value('value');
+        if (!empty($osm)) {
+            return $osm;
+        }
+        return in_array($this->egyhazmegye, [34, 17, 18]) ? 'greek_catholic' : 'roman_catholic';
     }
     
     public function getHoldersAttribute($value) {

--- a/webapp/classes/eloquent/email.php
+++ b/webapp/classes/eloquent/email.php
@@ -21,10 +21,10 @@ class Email extends \Illuminate\Database\Eloquent\Model {
     
     function send($to = false) {
         if($to) $this->to = $to;
-                        
+
         $this->status = 'sending';
         $this->save();
-        
+
         if ($this->debug == 1) {
             $this->header .= 'Bcc: ' . $this->debugger . "\r\n";
         } elseif ($this->debug == 2) {
@@ -35,43 +35,80 @@ class Email extends \Illuminate\Database\Eloquent\Model {
         if (isset($this->subject) AND isset($this->body) AND isset($this->to)) {
             if ($this->debug == 3) {
                 print_r($this);
+                $this->status = 'debug';
+                $this->save();
+                return true;
             } else if ($this->debug == 5) {
                 // black hole
+                $this->status = 'blackhole';
+                $this->save();
+                return true;
             } else {
-			
-				$mail = $this->createMailer(); 
+                // #610: konfigurálatlan SMTP-vel meg se próbálkozunk. Korábban ilyenkor a
+                // beégetett 'mailcatcher' hostra ment minden levél, ami production-ben vagy
+                // némán elnyelte a leveleket, vagy elszálló kivételt dobott a regisztráció
+                // közepén (a sor pedig örökre 'sending' státuszban ragadt).
+                if (!$this->isMailerConfigured()) {
+                    return $this->fail('Nincs beállítva SMTP kiszolgáló (SMTP_HOST).');
+                }
 
-				//$mail->addAddress('joe@example.net', 'Joe User');     //Add a recipient
-				$mail->addAddress($this->to);               //Name is optional
-				//$mail->addReplyTo('info@example.com', 'Information');
-				//$mail->addCC('cc@example.com');
-				//$mail->addBCC('bcc@example.com');
+                try {
+                    $mail = $this->createMailer();
 
-				//Attachments
-				//$mail->addAttachment('/var/tmp/file.tar.gz');         //Add attachments
-				//$mail->addAttachment('/tmp/image.jpg', 'new.jpg');    //Optional name
+                    //$mail->addAddress('joe@example.net', 'Joe User');     //Add a recipient
+                    $mail->addAddress($this->to);               //Name is optional
+                    //$mail->addReplyTo('info@example.com', 'Information');
+                    //$mail->addCC('cc@example.com');
+                    //$mail->addBCC('bcc@example.com');
 
-				//Content
-				$mail->isHTML(true);                                  //Set email format to HTML
-				$mail->Subject = $this->subject;
-				$mail->Body    = $this->body;
-				//$mail->AltBody = 'This is the body in plain text for non-HTML mail clients';
-						
-                if (!$mail->send()) {
-                    addMessage('Valami hiba történt az email elküldése közben.', 'danger');
-                    $this->status = "error";
-                    $this->save();
-                } else {
+                    //Attachments
+                    //$mail->addAttachment('/var/tmp/file.tar.gz');         //Add attachments
+                    //$mail->addAttachment('/tmp/image.jpg', 'new.jpg');    //Optional name
+
+                    //Content
+                    $mail->isHTML(true);                                  //Set email format to HTML
+                    $mail->Subject = $this->subject;
+                    $mail->Body    = $this->body;
+                    //$mail->AltBody = 'This is the body in plain text for non-HTML mail clients';
+
+                    if (!$mail->send()) {
+                        return $this->fail($mail->ErrorInfo);
+                    }
+
                     $this->status = 'sent';
                     return $this->save();
+                } catch (\Throwable $error) {
+                    // A PHPMailer exception-módban fut (new PHPMailer(true)), a hívók
+                    // viszont sehol nem kapják el: elszállt tőle az egész kérés.
+                    return $this->fail($error->getMessage());
                 }
             }
-        } else {            
-            addMessage('Nem tudtuk elküldeni az emailt. Kevés az adat.', 'danger');
         }
-        $this->status = "error";
+
+        return $this->fail(
+            'Kevés az adat (címzett, tárgy vagy törzs hiányzik).',
+            'Nem tudtuk elküldeni az emailt. Kevés az adat.'
+        );
+    }
+
+    /**
+     * #610: egységes hibaág — a levél státusza NE ragadjon 'sending'-ben, és a valódi
+     * SMTP-hibaüzenet kerüljön a szerver logjába (a felhasználónak csak jelzés megy).
+     */
+    protected function fail($reason, $userMessage = 'Valami hiba történt az email elküldése közben.') {
+        $this->status = 'error';
         $this->save();
+
+        error_log('miserend email hiba (id: ' . ($this->id ?: '-') . ', to: ' . $this->to . '): ' . $reason);
+        addMessage($userMessage, 'danger');
+
         return false;
+    }
+
+    function isMailerConfigured() {
+        global $config;
+
+        return isset($config['smtp']['Host']) AND trim((string) $config['smtp']['Host']) !== '';
     }
     
     function __construct() {   
@@ -127,29 +164,45 @@ class Email extends \Illuminate\Database\Eloquent\Model {
 	}
 	
 	function test($content = false) {
-        global $user;
+        global $user, $config;
+
+		// #610: a "nincs SMTP beállítva" eset korábban nem látszott, mert a config
+		// beégetett 'mailcatcher' alapértéke mindig adott valamit.
+		if(!$this->isMailerConfigured()) {
+			return "Nincs beállítva SMTP kiszolgáló (SMTP_HOST).";
+		}
+
+		// A dev mailcatcher elnyeli a leveleket: production/staging alatt a "sikeres"
+		// teszt ilyenkor is OK-ot mutatna, miközben senki nem kap levelet.
+		if(in_array($config['env'], ['production','staging']) AND $config['smtp']['Host'] == 'mailcatcher') {
+			return "A(z) ".$config['env']." környezet a dev mailcatcher-re küld: minden levél elveszik! Állítsd be az SMTP_HOST-ot.";
+		}
 
 		$mailer = $this->createMailer();
 		try {
 			$connection = $mailer->SmtpConnect();
-		} catch(Exception $error) {
-			return "PHPMailer Failed to connect : " . $error;
+		} catch(\Throwable $error) {
+			return "PHPMailer Failed to connect : " . $error->getMessage();
 		}
-		
-		$mailer->addAddress($this->debugger);               
-		$mailer->isHTML(true);                                  
+
+		$mailer->addAddress($this->debugger);
+		$mailer->isHTML(true);
 		$mailer->Subject = 'miserend.hu - egészség ellenőrzés';
 		$mailer->Body    = '';
 		if($content) {
             $mailer->Body .= "\n\n" . $content;
-        }   
+        }
 
-		if(!$mailer->send()) {
-			return "Valami hiba történt teszt email kiküldése közben.";
+		try {
+			if(!$mailer->send()) {
+				return "Valami hiba történt teszt email kiküldése közben: " . $mailer->ErrorInfo;
+			}
+		} catch(\Throwable $error) {
+			return "Valami hiba történt teszt email kiküldése közben: " . $error->getMessage();
 		}
-			
+
 		return "OK";
-	
+
 	}
     
 }

--- a/webapp/classes/html/health.php
+++ b/webapp/classes/html/health.php
@@ -253,8 +253,17 @@ class Health extends Html {
 			->get();
 
 		$this->mailing = $config['smtp'];
+		unset($this->mailing['Password']); // a health oldal ne szivárogtassa ki
 		$this->mailing['debug'] = $config['mail']['debug'];
-		
+
+		// #610: a levélküldés némán dőlt el a konfigurációnál — ez legyen látható.
+		$this->mailing['warning'] = false;
+		if (trim((string) $this->mailing['Host']) === '') {
+			$this->mailing['warning'] = 'Nincs beállítva SMTP kiszolgáló (SMTP_HOST): egyetlen levél sem megy ki.';
+		} elseif (in_array($config['env'], ['production','staging']) AND $this->mailing['Host'] == 'mailcatcher') {
+			$this->mailing['warning'] = 'A(z) '.$config['env'].' környezet a dev mailcatcher-re küld: minden levél elveszik.';
+		}
+
 		$email = new \Eloquent\Email();
 
 		$html = '';

--- a/webapp/config.php
+++ b/webapp/config.php
@@ -28,12 +28,21 @@ $environment['default'] = [
         'web' => "2 weeks",
 		'API' => "15 minutes"
     ],
+	// #610: az SMTP kizárólag env-ből jön, és a `default` ág SZÁNDÉKOSAN üres Host-tal
+	// indul. Korábban itt 'mailcatcher' volt az alapérték, így production-ben — ahol a
+	// compose sosem adta át az SMTP_HOST-ot — minden levél a dev mailcatcher-be ment és
+	// némán elnyelődött (a /health közben "OK"-ot mutatott). Üres Host esetén inkább
+	// hangosan hibázunk, l. \Eloquent\Email::send().
 	'smtp' => [
-		'Host' => env('SMTP_HOST', 'mailcatcher'),
-		'Port' => env('SMTP_PORT', 1025),
-		'SMTPAuth' => false,
-		'SMTPSecure' => false
-	],		
+		'Host' => env('SMTP_HOST', ''),
+		// Üres env-változó esetén az env() üres sztringet ad vissza (nem az alapértéket),
+		// abból pedig 0-s port lenne — ezért az ?: fallback.
+		'Port' => ((int) env('SMTP_PORT', 25)) ?: 25,
+		'SMTPAuth' => (bool) env('SMTP_USER', false),
+		'Username' => env('SMTP_USER', ''),
+		'Password' => env('SMTP_PASSWORD', ''),
+		'SMTPSecure' => env('SMTP_SECURE', '')
+	],
     'mail' => [
         'sender' => ['info@miserend.hu','miserend.hu'],
         'debug' => 0, /* 0,1,2,3,5 */
@@ -47,7 +56,12 @@ $environment['testing'] = [
     'debug' => 1,
     'mail' => [
         'debug' => 5
-    ],   
+    ],
+	// A mailcatcher-alapérték csak itt és development-ben él (l. #610).
+	'smtp' => [
+		'Host' => env('SMTP_HOST', 'mailcatcher'),
+		'Port' => ((int) env('SMTP_PORT', 1025)) ?: 1025
+	],
     'error_reporting' => E_ERROR | E_WARNING | E_PARSE
 ];
 
@@ -77,6 +91,10 @@ $environment['development'] = [
     'mail' => [
         'debug' => 0
     ],
+	'smtp' => [
+		'Host' => env('SMTP_HOST', 'mailcatcher'),
+		'Port' => ((int) env('SMTP_PORT', 1025)) ?: 1025
+	],
     'path' => [
         'domain' => 'http://localhost:8000'
     ],

--- a/webapp/templates/health.twig
+++ b/webapp/templates/health.twig
@@ -283,7 +283,11 @@
 	
 	<table class="table table-hover table-condensed table-striped">
 			<tr>
-				<td>Host:Port</td><td>{{ mailing.Host }}:{{ mailing.Port }}</td>
+				<td>Host:Port</td>
+				<td>
+					<span class="{% if mailing.warning %}table-danger{% endif %}">{{ mailing.Host|default('(nincs beállítva)') }}:{{ mailing.Port }}</span>
+					{% if mailing.warning %}<br/><span class="table-danger">{{ mailing.warning }}</span>{% endif %}
+				</td>
 			</tr>
 			<tr>
 				<td>debug level</td><td>{{ mailing.debug }}</td>

--- a/webapp/tests/Integration/EmailSendingTest.php
+++ b/webapp/tests/Integration/EmailSendingTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * #610: "Nem küld emailt".
+ *
+ * A config.php-ban az SMTP Host alapértéke 'mailcatcher' volt, a production compose
+ * viszont sosem adta át az SMTP_HOST-ot a konténernek. Így éles környezetben minden
+ * levél a dev mailcatcher-be ment (némán elnyelődött), vagy — ha az nem futott —
+ * a PHPMailer elkapatlan kivétele szállt el a regisztráció közepén, a levél sora
+ * pedig örökre 'sending' státuszban ragadt.
+ *
+ * Tranzakcióban fut, tearDown-ban rollback.
+ */
+class EmailSendingTest extends TestCase
+{
+    /** @var array */
+    private $originalConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $config;
+        $this->originalConfig = $config;
+        DB::beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        DB::rollBack();
+        global $config;
+        $config = $this->originalConfig;
+        parent::tearDown();
+    }
+
+    /**
+     * A config.php-t friss környezettel értékeli ki: az SMTP_* env-változókat
+     * ideiglenesen kiveszi, hogy a config alapértékeit lássuk.
+     */
+    private function configFor(string $env): array
+    {
+        $keys  = ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASSWORD', 'SMTP_SECURE'];
+        $saved = [];
+        foreach ($keys as $key) {
+            $saved[$key] = getenv($key);
+            putenv($key);
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+
+        try {
+            $environment = [];
+            require PATH . 'config.php';
+
+            $resolved        = $environment['default'];
+            $resolved['env'] = $env;
+            if (isset($environment[$env])) {
+                overrideArray($resolved, $environment[$env]);
+            }
+
+            return $resolved;
+        } finally {
+            foreach ($saved as $key => $value) {
+                if ($value !== false) {
+                    putenv($key . '=' . $value);
+                    $_ENV[$key] = $value;
+                }
+            }
+        }
+    }
+
+    /** Ez a #610 közvetlen regresszió-őre. */
+    public function testProductionDoesNotFallBackToDevMailcatcher(): void
+    {
+        $config = $this->configFor('production');
+
+        $this->assertNotSame(
+            'mailcatcher',
+            $config['smtp']['Host'],
+            'Production nem küldhet a dev mailcatcher-be: ott minden levél elveszik.'
+        );
+        $this->assertSame(
+            '',
+            $config['smtp']['Host'],
+            'SMTP_HOST nélkül a production Host maradjon üres, hogy a hiba látszódjon.'
+        );
+    }
+
+    public function testStagingDoesNotFallBackToDevMailcatcher(): void
+    {
+        $config = $this->configFor('staging');
+
+        $this->assertNotSame('mailcatcher', $config['smtp']['Host']);
+    }
+
+    public function testDevelopmentAndTestingStillDefaultToMailcatcher(): void
+    {
+        $this->assertSame('mailcatcher', $this->configFor('development')['smtp']['Host']);
+        $this->assertSame(1025, $this->configFor('development')['smtp']['Port']);
+        $this->assertSame('mailcatcher', $this->configFor('testing')['smtp']['Host']);
+    }
+
+    public function testUnreachableSmtpMarksTheEmailErroredInsteadOfThrowing(): void
+    {
+        global $config;
+        // Zárt port a loopbacken: azonnali "connection refused", DNS nélkül.
+        $config['smtp']['Host'] = '127.0.0.1';
+        $config['smtp']['Port'] = 9;
+
+        $email          = new \Eloquent\Email();
+        $email->debug   = 0;
+        $email->subject = 'phpunit';
+        $email->body    = 'phpunit';
+
+        $this->assertFalse(
+            $email->send('phpunit@example.invalid'),
+            'Elérhetetlen SMTP esetén false a visszatérés — és nem elkapatlan kivétel.'
+        );
+        $this->assertSame(
+            'error',
+            DB::table('emails')->where('id', $email->id)->value('status'),
+            "A sor ne ragadjon 'sending' státuszban."
+        );
+    }
+
+    public function testMissingSmtpHostFailsFastWithoutConnecting(): void
+    {
+        global $config;
+        $config['smtp']['Host'] = '';
+
+        $email          = new \Eloquent\Email();
+        $email->debug   = 0;
+        $email->subject = 'phpunit';
+        $email->body    = 'phpunit';
+
+        $this->assertFalse($email->send('phpunit@example.invalid'));
+        $this->assertFalse($email->isMailerConfigured());
+        $this->assertSame(
+            'error',
+            DB::table('emails')->where('id', $email->id)->value('status')
+        );
+    }
+
+    public function testHealthCheckReportsProductionPointingAtMailcatcher(): void
+    {
+        global $config;
+        $config['env']          = 'production';
+        $config['smtp']['Host'] = 'mailcatcher';
+
+        $email = new \Eloquent\Email();
+
+        $this->assertStringNotContainsString(
+            'OK',
+            $email->test(),
+            'A /health ne mondja OK-nak, ha éles környezetben a mailcatcher nyeli el a leveleket.'
+        );
+    }
+
+    public function testHealthCheckReportsMissingSmtpHost(): void
+    {
+        global $config;
+        $config['smtp']['Host'] = '';
+
+        $email = new \Eloquent\Email();
+
+        $this->assertStringContainsString('SMTP_HOST', $email->test());
+    }
+}


### PR DESCRIPTION
Fixes #610

## Ok

A `webapp/config.php`-ban az SMTP Host alapértéke `'mailcatcher'` volt, a `docker/compose.yml` prod service-e viszont csak a `MISEREND_WEBAPP_ENVIRONMENT`-et adta át a konténernek. A `.env` önmagában nem elég: a compose csak a saját interpolációjához olvassa, a PHP-hez nem jut el belőle semmi. Éles környezetben tehát minden levél a `mailcatcher:1025`-re ment — ha fut ott mailcatcher, elfogadja és elnyeli, ezért mutat a `/health` OK-ot, miközben senki nem kap levelet.

A regressziót az efa25978 ("health - phpmailer") hozta be: kivette a `if($config['env'] == 'production') $mail->isSendmail();` ágat, és mindent az akkor bevezetett, mailcatcher-alapértékű `$config['smtp']`-re állított. Sendmail-re visszaállni nem opció, a mai image-ben nincs `sendmail` binary.

Két másodlagos hiba miatt volt vak a debug:

- A PHPMailer exception-módban fut (`new PHPMailer(true)`), de sem az `Email::send()`, sem a hívói nem kapták el. Elérhetetlen SMTP esetén elszállt tőle az egész regisztrációs kérés, a levél sora pedig örökre `sending` státuszban ragadt (reprodukálva).
- Az `Email::test()` csak a connect hibáját kapta el, a valódi `ErrorInfo`-t sosem mutatta.

## Megoldás

- `config.php`: az SMTP kizárólag env-ből (`SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/`SMTP_PASSWORD`/`SMTP_SECURE`). A mailcatcher-alapérték csak `development`/`testing` alatt marad; Host nélkül nincs csendes dev-fallback.
- `docker/compose.yml`: a prod service átadja az `SMTP_*` változókat (`docker/.env`-ből).
- `Email::send()`: elkapja a kivételt, `error` státuszt ír (nem ragad `sending`-ben), a valódi SMTP-hibaüzenet `error_log`-ba kerül. A `debug=3/5` ágak sem jelölik tévesen hibásnak a levelet.
- `/health`: pirosan jelzi, ha nincs `SMTP_HOST`, vagy ha éles környezet a mailcatcher-re küld. Az SMTP-jelszó nem kerül bele a health oldal adataiba.
- `docker/compose.test.yml`: `SMTP_PORT` 11025 -> 1025. A 11025 a hoston publikált port, a compose-hálózaton belül a mailcatcher 1025-ön hallgat.

## Teszt

Új `webapp/tests/Integration/EmailSendingTest.php` (7 teszt): a production/staging config nem eshet vissza a mailcatcher-re, dev/test viszont igen; elérhetetlen és üres SMTP host esetén `false` a visszatérés és `error` a státusz, nem elkapatlan kivétel; a `/health` mindkét félrekonfigurálást jelzi.

A regresszió-őrt ellenőriztem: a régi configgal elbukik, az újjal átmegy. Teljes suite: 368 teszt, OK. A dev regisztráció végponttól végpontig újratesztelve, a levél megérkezik a mailcatcher-be.

## Deploy

A `docker/.env`-be be kell írni az `SMTP_HOST`-ot (és ha kell, `SMTP_PORT`/`SMTP_USER`/`SMTP_PASSWORD`/`SMTP_SECURE`), majd `docker compose -f docker/compose.yml up -d miserend`. Enélkül továbbra sem megy ki levél — de már láthatóan, a `/health` kiírja az okát.