### PR TITLE
Elvágom a külső betűtípusokat a funkcionális teszteknél

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -125,8 +125,35 @@ jobs:
             composer update --no-interaction --prefer-dist symfony/panther --with-all-dependencies
           fi
 
+      # A funkcionális tesztek a PUBLIKUS INTERNETTŐL függtek, és ettől időnként 12 percbe
+      # fulladtak a szokásos ~50 másodperc helyett.
+      #
+      # Az ok: a lefordított Angular Material CSS `@font-face` szabályai a
+      # `fonts.gstatic.com`-ról töltik a Robotót és a Material Symbolst. A Panther a
+      # `request()`-nél a TELJES oldalbetöltésre vár (document.readyState === 'complete'),
+      # ami a betűtípusokat is magában foglalja. Ha a gstatic lassú vagy elérhetetlen a
+      # runnerről, minden egyes oldalletöltés ~2 percet áll — tesztenként.
+      #
+      # Kimérve, ugyanaz az oldal, ugyanaz a csomag:
+      #   internettel .................. beakadt (>45 mp)
+      #   csak a fonts.gstatic.com tiltva ....... 1 mp
+      #
+      # A teszt-futásnak nincs szüksége a Google betűtípusaira: a méréseket és a DOM-ot
+      # nem befolyásolják. Itt tehát elvágjuk őket, hogy a futás hermetikus legyen.
+      #
+      # (Maga a függőség viszont az ÉLES oldalon is ott van — minden látogató böngészője
+      # hívja a Google-t, és minden oldalletöltés vár rá. Az külön kérdés, nem ez a lépés
+      # oldja meg.)
+      - name: Cut off external fonts for hermetic browser tests
+        run: |
+          sudo tee -a /etc/hosts > /dev/null <<'EOF'
+          127.0.0.1 fonts.gstatic.com
+          127.0.0.1 fonts.googleapis.com
+          127.0.0.1 oss.maxcdn.com
+          EOF
+
       - name: Run functional tests
-        # Normálisan ~80 másodperc. Ha a böngésző beakad, itt bukjon el, ne a job
+        # Normálisan ~50 másodperc. Ha a böngésző beakad, itt bukjon el, ne a job
         # felső korlátjánál — így a Docker-naplós lépés is lefut és látszik az ok.
         timeout-minutes: 12
         working-directory: webapp/tests


### PR DESCRIPTION
Nincs hozzá jegy: a #741 (és korábban a #740) funkcionális tesztje beakadt, és ennek jártam utána.

Szerkezeti hiba van.

## Mi történt

A funkcionális készlet normálisan **~50 másodperc**:

| PR | funkcionális lépés |
|---|---|
| #736 | 58 mp ✅ |
| #737 | 44 mp ✅ |
| #739 | 55 mp ✅ |
| #740 (újrafuttatva) | 50 mp ✅ |
| #741 | **12 perc 13 mp** ❌ |

A naplóban a PHPUnit kiírta a fejlécet, aztán 12 percen át semmit. Ez elsőre böngésző-indulási akadásnak látszott — **nem az.**

A konténer naplója szerint az app **végig kapott kéréseket**, szabályos ritmusban:

```
06:19:53  GET /?q=SearchResultsChurches&kulcsszo=Budapest
06:19:54  GET /templom/2474
          … majd ~2 perc teljes csend …
06:22:10  GET /?q=SearchResultsChurches&kulcsszo=Budapest
06:22:10  GET /templom/2474
          … újabb ~2 perc csend …
```

Hat ilyen ciklus. Vagyis a tesztek **futottak**, csak fejenként ~2 percbe teltek pár másodperc helyett.

## Az ok

A lefordított **Angular Material CSS `@font-face` szabályai a `fonts.gstatic.com`-ról** töltik a Robotót és a Material Symbolst:

```css
@font-face{font-family:Roboto;...;src:url(https://fonts.gstatic.com/s/roboto/v47/...woff2)}
@font-face{font-family:Material Symbols Outlined;...;src:url(https://fonts.gstatic.com/...)}
```

A Panther a `request()`-nél a **teljes oldalbetöltésre** vár (`document.readyState === 'complete'`), ami a betűtípusokat is magában foglalja. Ha a gstatic lassú vagy elérhetetlen a runnerről, **minden egyes oldalletöltés megáll** — tesztenként.

## Kimérve

Ugyanaz az oldal, ugyanaz a csomag, csak a hálózat különbözik:

| | eredmény |
|---|---|
| internettel | **beakadt (>45 mp)** |
| minden külső hoszt tiltva | **1 mp** |
| **csak a `fonts.gstatic.com` tiltva** | **1 mp** |

Az utolsó sor a lényeg: egyetlen hoszt okozza az egészet.

Mellékesen ez azt is bizonyítja, hogy **nem a #741 Angular-változtatása a hibás** — a mérést a master csomagjával (`main-W5BRT6OR.js`) végeztem, ugyanígy beakadt.

## Mit tettem

A runner `hosts` fájljában elvágom a `fonts.gstatic.com`, `fonts.googleapis.com` és `oss.maxcdn.com` hosztokat a funkcionális tesztek előtt. A tesztek se a méréseket, se a DOM-ot nem alapozzák ezekre.

Szándékosan **nem** `PANTHER_CHROME_ARGUMENTS`-szal: az szóköz mentén darabolja az értéket, a `--host-resolver-rules` szintaxisa viszont szóközt tartalmaz. A `browser_arguments` pedig felülírná a Panther alapértelmezéseit (`--headless`, `--no-sandbox`), amit nem érdemes lemásolni. A hosts-fájl egyszerű és pontosan azt mondja ki, amitől a teszteknek függetlennek kell lenniük.

Kipróbáltam egy halott proxyt is (`--proxy-server=127.0.0.1:1`) — az **nem** oldja meg, a Chrome ott is vár.

## ⚠️ Amit ez NEM old meg

**Az éles oldal is így működik.** Minden látogató böngészője hívja a Google-t minden oldalletöltésnél, és a betöltés vár rá. Ez két dolog egyszerre:

- **teljesítmény** — a lassú gstatic a valódi látogatót ugyanúgy megvárakoztatja;
- **adatvédelem** — a látogató IP-je és User-Agentje elmegy a Google-hoz, hozzájárulás nélkül. Ez pont az a fajta dolog, amit a `nearby.log`-nál (#735) most szüntettünk meg, és amit a `/gdpr` szövege sem említ.

A megoldás a betűtípusok saját kiszolgálása: a `calendar_deploy.py` már úgyis utófeldolgozza ezt a CSS-t (rem→px), tehát build időben le tudná tölteni a woff2 fájlokat és átírni az URL-eket. **Szólj, ha csináljam** — külön PR-ben, mert ez már a látogatókat érinti, nem a CI-t.